### PR TITLE
Feature/new about

### DIFF
--- a/about.md
+++ b/about.md
@@ -11,6 +11,7 @@ It allow for automated testing of:
 * Packages
 * Functions
 * Procedures
+* Triggers
 * Views
 * Anything else that can be execute and observed from PL/SQL
 

--- a/about.md
+++ b/about.md
@@ -11,13 +11,63 @@ It allow for automated testing of:
 * Packages
 * Functions
 * Procedures
-* Anything else that can be execute and observed from PL/SQL 
-   
+* Views
+* Anything else that can be execute and observed from PL/SQL
 
-utPLSQL was originally developed by [Steven Feuerstein](http://stevenfeuerstein.com/).
-
-It is currently developed and maintained by a team of passionate developers.
+utPLSQL is developed 100% voluntarily and embraces a [Code of Conduct](https://github.com/utPLSQL/utPLSQL/blob/develop/CODE_OF_CONDUCT.md).
 
 Feel free to [try it out](/downloads), you won't regret it.
 Additional information can be found in the [documentation](/documentation) pages.
 
+
+## Version 3
+
+While the framework exists since 1999, the current version 3 got completely rewritten in 2016 by passionate members of 
+the community, using the object-oriented capabilities of the Oracle database to make it more consistent with other
+*Unit frameworks (e.g. JUnit for Java). 
+  
+This had significant impact on the syntax and the way the framework can be used.
+   
+# Contributors
+
+## Major Active Maintainers
+
+| Name                                                  | Comments  
+| ----------------------------------------------------- | --------------
+| [Jacek Gebal](https://twitter.com/GebalJacek/)        | Project lead 
+| [Pavel Kaplya](https://twitter.com/Pazus)             | 
+| [Samuel Nitsche](https://twitter.com/Der_Pesse)       |
+| [Lukasz Wasylow](https://twitter.com/Baalowy)         |
+| [Philipp Salvisberg](https://twitter.com/phsalvisberg)|
+
+Many thanks to [all the contributors](https://github.com/utPLSQL/utPLSQL/graphs/contributors).
+
+## Major Contributors
+
+| Name                                               | Comments  
+| -------------------------------------------------- | --------------
+| Robert Love                                        |  
+| David Pyke                                         | 
+| [Vinicius Avellar](https://twitter.com/mrvmoreira) |
+
+## Prior Major Contributors
+
+| Name                                              | Comments  
+| ------------------------------------------------- | --------------
+| [Steven Feuerstein](http://stevenfeuerstein.com/) | Original Author  
+| Chris Rimmer                                      | 
+| Patrick Barel                                     |
+| Paul Walker                                       |
+
+# Supporters
+
+The utPLSQL project is community-driven and is not commercially motivated. Nonetheless, donations and other contributions are always welcome, and are detailed below.
+
+<table>
+<tbody>
+<tr>
+<td><a href="https://www.red-gate.com/hub/events/open-source-projects" rel="nofollow"><img src="docs/images/supported_by_redgate_100.png" alt="supported_by_redgate" style="max-width:100%;"></a></td>
+<td>utPLSQL has been supported by Redgate in the form of sponsored stickers and t-shirts. Thank you for helping us spreading the word!</td>
+</tr>
+</tbody>
+</table>


### PR DESCRIPTION
Improves the about page.
- Lists the active major maintainers, the major (but not active anymore) contributers and the major contributors of the prior versions
- Adds a little bit of history
- Points out that Version 3 is pretty different
- Adds a supporters-section